### PR TITLE
ページ右端のTOCに折りたたみとスクロール機能を追加する

### DIFF
--- a/layouts/partials/page-toc.html
+++ b/layouts/partials/page-toc.html
@@ -19,13 +19,13 @@
                 {{- else if eq $prev_level `3` -}}
                     </ul>
                 </details>
-                </li>
                 {{- end -}}
                 {{- if . | findRE "class=.*?pdftoc.*?" }}
-                <details>
-                <summary><a href="#{{ $id }}" class="pdftoc">{{ $header }}</a></summary>
+                <details open>
+                    <summary><a href="#{{ $id }}" class="pdftoc">{{ $header }}</a></summary>
                 {{- else }}
-                <summary><a href="#{{ $id }}">{{ $header }}</a></summary>
+                <details open>
+                    <summary><a href="#{{ $id }}">{{ $header }}</a></summary>
                 {{- end }}
             {{- else if eq $level `3` -}}
                 {{- if eq $prev_level `2` -}}
@@ -44,8 +44,10 @@
 
         {{- $prev_level := $scratch.Get "prev_level" -}}
         {{- if eq $prev_level `2` -}}
+        </details>
         {{- else if eq $prev_level `3` -}}
             </ul>
+        </details>
         {{- end -}}
     </ul>
 </nav>

--- a/layouts/partials/page-toc.html
+++ b/layouts/partials/page-toc.html
@@ -15,14 +15,17 @@
             {{- $prev_level := $scratch.Get "prev_level" -}}
             {{- if eq $level `2` -}}
                 {{- if eq $prev_level `2` -}}
-                    </li>
+                    </details>
                 {{- else if eq $prev_level `3` -}}
-                    </ul></li>
+                    </ul>
+                </details>
+                </li>
                 {{- end -}}
                 {{- if . | findRE "class=.*?pdftoc.*?" }}
-                <li><a href="#{{ $id }}" class="pdftoc">{{ $header }}</a>
+                <details>
+                <summary><a href="#{{ $id }}" class="pdftoc">{{ $header }}</a></summary>
                 {{- else }}
-                <li><a href="#{{ $id }}">{{ $header }}</a>
+                <summary><a href="#{{ $id }}">{{ $header }}</a></summary>
                 {{- end }}
             {{- else if eq $level `3` -}}
                 {{- if eq $prev_level `2` -}}
@@ -41,9 +44,8 @@
 
         {{- $prev_level := $scratch.Get "prev_level" -}}
         {{- if eq $prev_level `2` -}}
-            </li>
         {{- else if eq $prev_level `3` -}}
-            </ul></li>
+            </ul>
         {{- end -}}
     </ul>
 </nav>

--- a/static/css/vivlio-theme-manual.css
+++ b/static/css/vivlio-theme-manual.css
@@ -785,6 +785,8 @@ figure img.fig ~ figcaption::before {
     display: inline;
     position: fixed;
     top: 50px;
+    bottom: 50px;
+    overflow-y: auto;
     left: calc(var(--menu-width) + var(--content-width));
     width: calc(98% - var(--menu-width) - var(--content-width));
     font-size: 0.8em;


### PR DESCRIPTION
@mochimochiki 
素晴らしいProductをありがとうございます。

ページ右端に表示されるTableOfContents（以下TOCと表記）に、以下の機能を追加しました。  
いずれも、TOCに表示する内容が多くなった場合にブラウザの表示画面に収まらない問題を解決するのが目的です。  
ご確認いただけますと幸いです 😸 

- `details`要素を使って、見出し2以降を折りたたみ可能にしました。
- TOCにスクロール機能を追加しました。