### PR TITLE
PDFとWebページのTOC生成を分けて互いに影響が出ないようにする

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,7 +5,7 @@
   {{- $content := partial "content-with-section.html" (dict "sectionNo" $sectionNoRaw "page" .Page ) }}
   {{- .Scratch.Set "Content" $content }}
   {{- if ne .Site.Params.isPDF true }}
-    {{ partial "page-toc.html" $content }}
+    {{ partial "page-toc-sidebar.html" $content }}
     {{- $content = partial "functions/addAnchorNextToHeader" $content }}
   {{- end }}
   {{ $content }}

--- a/layouts/partials/page-toc-sidebar.html
+++ b/layouts/partials/page-toc-sidebar.html
@@ -4,7 +4,7 @@
 {{- $headers := findRE $pattern $Content -}}
 {{- $scratch := newScratch -}}
 {{- $scratch.Set "prev_level" 0 -}}
-<nav id="TableOfContents">
+<nav id="TableOfContents-sidebar">
     <ul>
         {{- range $headers -}}
             {{- $level := . | replaceRE $pattern `$1` -}}
@@ -15,14 +15,16 @@
             {{- $prev_level := $scratch.Get "prev_level" -}}
             {{- if eq $level `2` -}}
                 {{- if eq $prev_level `2` -}}
-                    </li>
+                    </details>
                 {{- else if eq $prev_level `3` -}}
-                    </ul></li>
+                    </ul>
+                </details>
                 {{- end -}}
                 {{- if . | findRE "class=.*?pdftoc.*?" }}
-                <li><a href="#{{ $id }}" class="pdftoc">{{ $header }}</a>
+                <details open><summary><a href="#{{ $id }}" class="pdftoc">{{ $header }}</a></summary>
                 {{- else }}
-                <li><a href="#{{ $id }}">{{ $header }}</a>
+                <details open>
+                    <summary><a href="#{{ $id }}">{{ $header }}</a></summary>
                 {{- end }}
             {{- else if eq $level `3` -}}
                 {{- if eq $prev_level `2` -}}
@@ -41,9 +43,10 @@
 
         {{- $prev_level := $scratch.Get "prev_level" -}}
         {{- if eq $prev_level `2` -}}
-            </li>
+        </details>
         {{- else if eq $prev_level `3` -}}
-            </ul></li>
+            </ul>
+        </details>
         {{- end -}}
     </ul>
 </nav>

--- a/static/css/vivlio-theme-manual.css
+++ b/static/css/vivlio-theme-manual.css
@@ -912,3 +912,46 @@ figure img.fig ~ figcaption::before {
 #humburger-btn-check {
   display: none;
 }
+
+/* ---------------- */
+/* page toc sidebar */
+/* ---------------- */
+@media screen and (min-width: 1500px) and (orientation: landscape) {
+  #TableOfContents-sidebar {
+    display: inline;
+    position: fixed;
+    top: 50px;
+    bottom: 50px;
+    overflow-y: auto;
+    left: calc(var(--menu-width) + var(--content-width));
+    width: calc(98% - var(--menu-width) - var(--content-width));
+    font-size: 0.8em;
+    border-radius: 0.1em;
+    border: solid 1px lightgray;
+    background: inherit;
+    padding: 0;
+  }
+  #TableOfContents-sidebar > ul:before {
+    content: "目次";
+    font-weight: bolder;
+  }
+  #TableOfContents-sidebar  h2 {
+    background: inherit;
+    text-align: inherit;
+    border-bottom: 1px #eee solid;
+    padding: 10px;
+  }
+  #TableOfContents-sidebar  ul {
+    list-style-type: none;
+  }
+  #TableOfContents-sidebar  li {
+    padding-top: 0;
+  }
+  #TableOfContents-sidebar  li > ul {
+    padding-left: 1em;
+  }
+  #TableOfContents-sidebar  a {
+    font-weight: normal;
+    border-bottom: dashed 1px lightgray;
+  }
+}


### PR DESCRIPTION
@mochimochiki 

すみません、先日マージしていただいた #24 によって、PDF化する際の目次に悪影響が出ていました。
確認が不足してしまい申し訳ございません。修正しましたのでご確認お願いします。

また、`details`の`summary`に配置したリンクが、▼マークの下に配置されてしまっていたのを直しました。