### PR TITLE
GitHub上のMarkdownなどを参照する際にリンクがhtmlに変換されてしまう問題を修正

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,13 +1,15 @@
 {{- $url := .Destination | safeURL | urls.Parse }}
 {{- $path := $url.Path }}
 {{- if strings.HasSuffix $path "md" }}
-  {{- $path = $path | replaceRE "\\.md$" ".html" }}
-  {{- if ne $url.RawQuery "" }}
-    {{- $path = printf "%s?%s" $path $url.RawQuery }}
+  {{- if not (strings.HasPrefix $url.Scheme "http") }}
+    {{- $path = $path | replaceRE "\\.md$" ".html" }}
+    {{- if ne $url.RawQuery "" }}
+      {{- $path = printf "%s?%s" $path $url.RawQuery }}
+    {{- end }}
+    {{- if ne $url.Fragment "" }}
+      {{- $path = printf "%s#%s" $path $url.Fragment }}
+    {{- end }}
+    {{- $url = $path | safeURL | urls.Parse }}
   {{- end }}
-  {{- if ne $url.Fragment "" }}
-    {{- $path = printf "%s#%s" $path $url.Fragment }}
-  {{- end }}
-  {{- $url = $path | safeURL | urls.Parse }}
 {{- end }}
 <a href="{{$url | safeURL}}">{{.Text | safeHTML }}</a>

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,7 +1,7 @@
 {{- $url := .Destination | safeURL | urls.Parse }}
 {{- $path := $url.Path }}
 {{- if strings.HasSuffix $path "md" }}
-  {{- if not (strings.HasPrefix $url.Scheme "http") }}
+  {{- if not $url.IsAbs }}
     {{- $path = $path | replaceRE "\\.md$" ".html" }}
     {{- if ne $url.RawQuery "" }}
       {{- $path = printf "%s?%s" $path $url.RawQuery }}


### PR DESCRIPTION
GitHub上の別リポジトリにあるMakkdownファイルを参照するようなリンクを記載した場合に、Hugo文書の一部のようなリンクに変換されてしまう問題を修正しました。
ご確認お願いいたしますm(_ _)m