### PR TITLE
画像サイズを指定する際も、src属性にクエリパラメータを含めないように変更

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -8,6 +8,7 @@
   {{- $path := (printf "%s/%s" $sectionName $url.Path ) | urlize}}
   {{- $url = $path | safeURL | urls.Parse }}
 {{- end }}
+{{- $url = index (split $url "?") 0 }}
 {{- if .PlainText | findRE "[^\\s]" }}
 {{- /* 代替テキストがあるならキャプション表示 */}}
 <figure {{ if $ispdf | and (gt $maxheight 0) }}style="max-height: {{ $maxheight}}mm;"{{ end }}>


### PR DESCRIPTION
`画像サイズの変更（属性の付加）`機能を使ってMarkdown原稿に画像を埋め込んだ場合、HTML要素へと変換すると`img`要素の`src`属性に「?border=10&width=50%」が含まれていました。

ブラウザで表示する分には問題ないのですが、あまりお作法的に`src`属性にクエリパラメータを含める例を見かけませんし、HTMLコンテンツをツールなどでパース・チェックなどする際の事故を防ぐ意味でも綺麗なURLにしたいと考えました💦

ご確認お願いいたしますm(_ _)m