### PR TITLE
Improve mermaid support

### DIFF
--- a/exampleSite/content/en/Manual/MarkdownShowcase.md
+++ b/exampleSite/content/en/Manual/MarkdownShowcase.md
@@ -131,6 +131,25 @@ Alice->>Bob: Hello Bob.
 Bob-->>Alice: Hello Alice.
 ```
 
+Annotations can also be used in class diagrams.
+
+```mermaid
+classDiagram
+class Shape{
+    <<interface>>
+    noOfVertices
+    draw()
+}
+class Color{
+    <<enumeration>>
+    RED
+    BLUE
+    GREEN
+    WHITE
+    BLACK
+}
+```
+
 ### Images
 
 #### Regular Image

--- a/exampleSite/content/ja/Manual/MarkdownShowcase.md
+++ b/exampleSite/content/ja/Manual/MarkdownShowcase.md
@@ -140,6 +140,25 @@ Alice->>Bob: Hello Bob.
 Bob-->>Alice: Hello Alice.
 ```
 
+`Annotation`はクラス図などでも使用できます。
+
+```mermaid
+classDiagram
+class Shape{
+    <<interface>>
+    noOfVertices
+    draw()
+}
+class Color{
+    <<enumeration>>
+    RED
+    BLUE
+    GREEN
+    WHITE
+    BLACK
+}
+```
+
 ### 図
 
 #### 通常の図

--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -13,6 +13,6 @@
   {{- if gt $pdfPageMaxHeight 0 }}<style>div[id={{$mermaid_id}}] svg { max-height: {{$pdfPageMaxHeight}}mm; }</style>{{ end }}
 {{- end }}
 <div class="mermaid" id="{{$mermaid_id}}" align="center">
-  {{ .Inner | safeHTML }}
+  {{ .Inner | htmlEscape | safeHTML }}
 </div>
 {{- .Page.Scratch.Set "use_mermaid" true }}


### PR DESCRIPTION
`html`で制御文字として扱われる`<`や`>`がエスケープされていなかったために問題が起きていたのだと思われます。
[Hugo公式のExamples](https://gohugo.io/render-hooks/code-blocks/#examples) にもあるように、`htmlEscape`処理を使ってエスケープすると良さそうです。

Close #97 