### PR TITLE
feat: Docker / GitHub Actions で exampleSite ビルドと PDF 生成を可能に

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# VCS / メタ
+.git
+.github
+.claude
+.agent
+
+# ビルド生成物
+**/node_modules
+exampleSite/public
+exampleSite/public_*
+exampleSite/static/viewer
+exampleSite/CI/linux/out
+exampleSite/CI/**/out
+
+# OS / エディタ
+**/.DS_Store
+**/Thumbs.db

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -1,0 +1,43 @@
+name: build pdf
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  pdf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true   # Fetch Hugo themes
+          fetch-depth: 0      # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Build Docker image
+        run: docker build -t hugo-theme-vivliocli:ci .
+
+      - name: Build PDFs in container
+        # リポジトリを WORKDIR(/work/hugo-theme-vivliocli)へマウントしてテーマ解決を成立させ、
+        # 生成 PDF をホスト(exampleSite/CI/linux/out)へ書き出す。
+        # MathJax/Mermaid は CDN から取得するためネットワークが必要(Actions では既定で利用可)。
+        # Chromium クラッシュ回避のため shm を拡張。
+        run: |
+          docker run --rm \
+            --shm-size=1g \
+            -v "${{ github.workspace }}":/work/hugo-theme-vivliocli \
+            hugo-theme-vivliocli:ci
+
+      - name: List generated PDFs
+        run: |
+          echo "Generated PDFs:"
+          find exampleSite/CI/linux/out -name '*.pdf' -print
+
+      - name: Upload PDF artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: vivliocli-pdf
+          path: exampleSite/CI/linux/out/**/*.pdf
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,8 @@ public_*/
 # Dependency directories
 node_modules/
 exampleSite/CI/windows/package-lock.json
+exampleSite/CI/linux/package-lock.json
 exampleSite/static/viewer/*
+
+# PDF build output (Linux/Docker)
+exampleSite/CI/linux/out/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# hugo-theme-vivliocli: exampleSite ビルド + Vivliostyle PDF 生成用イメージ
+#
+# 方針(ハンドオフ準拠):
+#   - Debian ベース(Vivliostyle CLI 公式 Dockerfile の依存に寄せる)
+#   - Hugo extended は gh-pages.yml と同じ v0.163.1
+#   - PDF/フォント依存: chromium, ghostscript, poppler-utils, Noto CJK, fontconfig
+#   - Chromium は apt 版を使用し Playwright/Vivliostyle 双方を /usr/bin/chromium に向ける
+FROM debian:bookworm-slim
+
+ARG HUGO_VERSION=0.163.1
+ARG TARGETARCH=amd64
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    # Playwright/Puppeteer のブラウザ自動DLを抑止し、apt の chromium を使う
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+    PUPPETEER_SKIP_DOWNLOAD=1 \
+    CHROMIUM_PATH=/usr/bin/chromium
+
+# 1. システム依存 + Node.js(NodeSource LTS) + Chromium / PDF / フォント
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      ca-certificates curl gnupg git \
+      chromium \
+      ghostscript poppler-utils \
+      fontconfig fonts-noto-cjk fonts-noto-cjk-extra fonts-noto-color-emoji; \
+    mkdir -p /etc/apt/keyrings; \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+      | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
+      > /etc/apt/sources.list.d/nodesource.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends nodejs; \
+    rm -rf /var/lib/apt/lists/*
+
+# 2. Hugo extended (gh-pages.yml と同一バージョン)
+RUN set -eux; \
+    curl -fsSL -o /tmp/hugo.deb \
+      "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${TARGETARCH}.deb"; \
+    apt-get install -y --no-install-recommends /tmp/hugo.deb; \
+    rm -f /tmp/hugo.deb; \
+    hugo version
+
+# 3. fontconfig エイリアス(Yu Gothic / Consolas 等 -> Noto CJK)
+COPY docker/fonts.conf /etc/fonts/conf.d/99-vivliocli-cjk.conf
+RUN fc-cache -f
+
+# テーマ解決のため、リポジトリは「hugo-theme-vivliocli」という名前のディレクトリに置く。
+# hugo.toml の themesdir="../.." + theme="hugo-theme-vivliocli" は、exampleSite から 2 階層上を
+# テーマ root とし、その下の hugo-theme-vivliocli をテーマとして解決する。よって
+#   exampleSite(/work/hugo-theme-vivliocli/exampleSite) の ../.. = /work
+#   theme = /work/hugo-theme-vivliocli = リポジトリ自身
+# となるように WORKDIR を配置する。(GitHub Actions の二重ネスト checkout と同じ仕組み)
+WORKDIR /work/hugo-theme-vivliocli
+
+# 自己完結イメージ(CI 用)。docker compose ではこの上に bind mount で上書きする。
+COPY . .
+
+# 既定では exampleSite の PDF をビルドする
+ENTRYPOINT ["bash", "exampleSite/CI/linux/build_pdf.sh"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ see the [User Guide](https://mochimochiki.github.io/hugo-theme-vivliocli/en/) fo
 * Install [Hugo](https://github.com/gohugoio/hugo) (v0.163.1 or later).
 * Install [Vivliostyle CLI](https://github.com/vivliostyle/vivliostyle-cli) (v8.6.0 or later).
 
+## Build with Docker
+
+You can build the `exampleSite` and generate the typeset PDFs without installing Hugo, Node.js, or Vivliostyle CLI locally. The Docker image (Debian based) bundles Hugo extended, Node.js, Chromium, Ghostscript, poppler, and Noto CJK fonts.
+
+```bash
+# Generate PDFs (output: exampleSite/CI/linux/out/<lang>/*.pdf)
+docker compose run --rm pdf
+
+# Use an additional edition config (config/<env>.toml)
+docker compose run --rm pdf edition
+
+# Live preview at http://localhost:1313/en/
+docker compose up preview
+```
+
+The PDF build also runs in GitHub Actions (`.github/workflows/pdf.yml`); the generated PDFs are uploaded as the `vivliocli-pdf` workflow artifact. The Linux build scripts live in [`exampleSite/CI/linux/`](exampleSite/CI/linux/) (the Windows equivalents in `exampleSite/CI/windows/` are unchanged).
+
+> Note: Mermaid and MathJax pages are pre-rendered with Chromium, which fetches the libraries from a CDN — network access is required during the build.
+
 ## License
 
 This project is licensed under the Apache License 2.0 - see the [LICENSE](https://github.com/mochimochiki/hugo-theme-vivliocli/blob/main/LICENSE) file for details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+# hugo-theme-vivliocli: ローカル開発用 Docker Compose
+#
+#   PDF 生成:  docker compose run --rm pdf            # exampleSite/CI/linux/out/<lang>/*.pdf
+#              docker compose run --rm pdf edition    # config/edition.toml を併用
+#   プレビュー: docker compose up preview             # http://localhost:1313/en/
+#
+# bind mount は Dockerfile の WORKDIR(/work/hugo-theme-vivliocli)へ重ねる。これにより
+# テーマ解決(themesdir="../.." + theme="hugo-theme-vivliocli")が成立し、生成 PDF は
+# ホストの exampleSite/CI/linux/out に出力される。
+services:
+  pdf:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: hugo-theme-vivliocli:latest
+    volumes:
+      - .:/work/hugo-theme-vivliocli
+    # ENTRYPOINT(build_pdf.sh)への引数(省略時は default)
+    command: []
+
+  preview:
+    image: hugo-theme-vivliocli:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    working_dir: /work/hugo-theme-vivliocli/exampleSite
+    environment:
+      # Preview.bat 相当(プレビューは PDF モードではない)
+      HUGO_PARAMS_ISPDF: "false"
+      # ADR-260614-02: プレビュー時のみ uglyURLs を無効化(自己参照エイリアスによる無限リロード回避)
+      HUGO_UGLYURLS: "false"
+    volumes:
+      - .:/work/hugo-theme-vivliocli
+    ports:
+      - "1313:1313"
+    entrypoint: ["bash", "-lc"]
+    command:
+      - "npm install && hugo server -D --bind 0.0.0.0 --port 1313 --baseURL http://localhost:1313/ --appendPort=false"

--- a/docker/fonts.conf
+++ b/docker/fonts.conf
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<!--
+  hugo-theme-vivliocli Docker 用 fontconfig エイリアス。
+  テーマ CSS や原稿が指定する Windows/macOS 系フォント名を、Docker 内に存在する
+  Noto CJK JP へ寄せて豆腐(□)化・代替フォント化を防ぐ。
+  Vivliostyle CLI 公式 fonts.conf の方針に準拠。
+-->
+<fontconfig>
+  <!-- ゴシック(サンセリフ)系 -> Noto Sans CJK JP -->
+  <match target="pattern">
+    <test name="family"><string>Yu Gothic</string></test>
+    <edit name="family" mode="assign" binding="strong"><string>Noto Sans CJK JP</string></edit>
+  </match>
+  <match target="pattern">
+    <test name="family"><string>YuGothic</string></test>
+    <edit name="family" mode="assign" binding="strong"><string>Noto Sans CJK JP</string></edit>
+  </match>
+  <match target="pattern">
+    <test name="family"><string>游ゴシック</string></test>
+    <edit name="family" mode="assign" binding="strong"><string>Noto Sans CJK JP</string></edit>
+  </match>
+  <match target="pattern">
+    <test name="family"><string>Meiryo</string></test>
+    <edit name="family" mode="assign" binding="strong"><string>Noto Sans CJK JP</string></edit>
+  </match>
+  <match target="pattern">
+    <test name="family"><string>MS Gothic</string></test>
+    <edit name="family" mode="assign" binding="strong"><string>Noto Sans CJK JP</string></edit>
+  </match>
+  <match target="pattern">
+    <test name="family"><string>Hiragino Kaku Gothic ProN</string></test>
+    <edit name="family" mode="assign" binding="strong"><string>Noto Sans CJK JP</string></edit>
+  </match>
+  <match target="pattern">
+    <test name="family"><string>Hiragino Sans</string></test>
+    <edit name="family" mode="assign" binding="strong"><string>Noto Sans CJK JP</string></edit>
+  </match>
+
+  <!-- 明朝(セリフ)系 -> Noto Serif CJK JP -->
+  <match target="pattern">
+    <test name="family"><string>Yu Mincho</string></test>
+    <edit name="family" mode="assign" binding="strong"><string>Noto Serif CJK JP</string></edit>
+  </match>
+  <match target="pattern">
+    <test name="family"><string>YuMincho</string></test>
+    <edit name="family" mode="assign" binding="strong"><string>Noto Serif CJK JP</string></edit>
+  </match>
+  <match target="pattern">
+    <test name="family"><string>游明朝</string></test>
+    <edit name="family" mode="assign" binding="strong"><string>Noto Serif CJK JP</string></edit>
+  </match>
+  <match target="pattern">
+    <test name="family"><string>MS Mincho</string></test>
+    <edit name="family" mode="assign" binding="strong"><string>Noto Serif CJK JP</string></edit>
+  </match>
+  <match target="pattern">
+    <test name="family"><string>Hiragino Mincho ProN</string></test>
+    <edit name="family" mode="assign" binding="strong"><string>Noto Serif CJK JP</string></edit>
+  </match>
+
+  <!-- 等幅系 -> Noto Sans Mono CJK JP（CJK 混在コードでも豆腐化しないように） -->
+  <match target="pattern">
+    <test name="family"><string>Consolas</string></test>
+    <edit name="family" mode="assign" binding="strong"><string>Noto Sans Mono CJK JP</string></edit>
+  </match>
+</fontconfig>

--- a/exampleSite/CI/linux/build_pdf.sh
+++ b/exampleSite/CI/linux/build_pdf.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# build_pdf.sh (Linux/Docker)
+#
+# Windows の build_pdf.bat の Linux 移植版。exampleSite の Hugo ビルドと Vivliostyle に
+# よる PDF 生成を一気通貫で実行する。
+#
+# Usage:
+#   build_pdf.sh [config_env]
+#     config_env を省略すると hugo.toml のみでビルド（publish dir: public_default）。
+#     config_env を指定すると --config hugo.toml,config/<env>.toml でビルド。
+#
+# Env:
+#   OUT_DIR        生成 PDF の集約先（既定: <CI/linux>/out）
+#   CHROMIUM_PATH  Chromium 実行ファイル（pre-render / Vivliostyle 用、Docker では /usr/bin/chromium）
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HUGO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"   # = exampleSite
+
+CONFIG_ENV="${1:-default}"
+if [ "${CONFIG_ENV}" = "default" ]; then
+  CONFIG_OPT=()
+else
+  CONFIG_OPT=(--config "hugo.toml,config/${CONFIG_ENV}.toml")
+fi
+PUBLISH_DIR="public_${CONFIG_ENV}"
+OUT_DIR="${OUT_DIR:-${SCRIPT_DIR}/out}"
+
+export HUGO_PARAMS_ISPDF=true
+
+echo "-------------------------------------"
+echo "Build Hugo site"
+echo "config           : ${CONFIG_ENV}"
+echo "target directory : ${PUBLISH_DIR}"
+echo "-------------------------------------"
+
+# 1. exampleSite の npm 依存（postinstall で @vivliostyle/viewer を static/viewer へコピー）
+( cd "${HUGO_DIR}" && npm install )
+
+# 2. Hugo ビルド（isPDF=true / baseURL=""）
+rm -rf "${HUGO_DIR:?}/${PUBLISH_DIR}"
+( cd "${HUGO_DIR}" && hugo "${CONFIG_OPT[@]}" -b "" -d "${PUBLISH_DIR}" )
+
+# 3. PDF ツールチェーンの npm 依存
+echo "-------------------------------------"
+echo "node : $(node -v)"
+echo "npm  : $(npm -v)"
+echo "-------------------------------------"
+( cd "${SCRIPT_DIR}" && npm install )
+
+# 4. JS 事前レンダリング（MathJax / Mermaid）
+node "${SCRIPT_DIR}/pre_js_rendering.js" "${HUGO_DIR}/${PUBLISH_DIR}"
+
+# 5. 言語ごとに config を集約して PDF 生成
+mkdir -p "${OUT_DIR}"
+for lang_path in "${HUGO_DIR}"/content/*/; do
+  lang="$(basename "${lang_path}")"
+  lang_root="${HUGO_DIR}/${PUBLISH_DIR}/${lang}"
+  [ -d "${lang_root}" ] || continue
+
+  echo "-------------------------------------"
+  echo "Build PDF  (language: ${lang})"
+  echo "-------------------------------------"
+  node "${SCRIPT_DIR}/collect_config.js" "${lang_root}"
+  node "${SCRIPT_DIR}/run_vivlio.js" "${lang_root}"
+
+  # 6. 生成 PDF を OUT_DIR/<lang>/ へ集約
+  shopt -s nullglob
+  pdfs=("${lang_root}"/*.pdf)
+  if [ ${#pdfs[@]} -gt 0 ]; then
+    mkdir -p "${OUT_DIR}/${lang}"
+    cp "${pdfs[@]}" "${OUT_DIR}/${lang}/"
+  fi
+  shopt -u nullglob
+done
+
+echo ""
+echo "build was completed."
+echo "PDFs: ${OUT_DIR}"
+ls -R "${OUT_DIR}" || true

--- a/exampleSite/CI/linux/collect_config.js
+++ b/exampleSite/CI/linux/collect_config.js
@@ -1,0 +1,71 @@
+/*
+ * collect_config.js (Linux/Docker)
+ *
+ * Linux 移植版。Windows の CollectConfig.ps1 と同じ挙動。
+ *
+ * 言語ルート(例 public_default/ja)配下を再帰し、各 PDF セクションに生成された
+ *   *.vivlio.cover.html / *.vivlio.config.js / *.vivlio.colophon.html
+ * を言語ルート直下へ「フラット名」でコピーする。
+ * フラット名は「言語ルートからの相対ディレクトリパスの区切りを '_' に置換」したもの。
+ *   例: Manual/_pdf.vivlio.config.js -> Manual.vivlio.config.js
+ *       twoColumns/_pdf.vivlio.cover.html -> twoColumns.vivlio.cover.html
+ * config.js 内の cover / colophon への参照もフラット名へ書き換える。
+ *
+ * Vivliostyle は config の entry/cover を config 配置ディレクトリ基準で解決するため、
+ * config を言語ルートに集約し cover/colophon を同階層へ置く必要がある。
+ *
+ * Usage: node collect_config.js <language_root_dir>
+ */
+const fs = require('fs');
+const path = require('path');
+
+function flatName(rootDir, fileDir) {
+  const rel = path.relative(rootDir, fileDir);
+  return rel.split(path.sep).join('_');
+}
+
+function processDir(rootDir, dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      processDir(rootDir, full);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+
+    const name = entry.name;
+    const prefix = flatName(rootDir, dir);
+
+    if (name.includes('.vivlio.cover.html')) {
+      const out = path.join(rootDir, `${prefix}.vivlio.cover.html`);
+      fs.copyFileSync(full, out);
+      console.log(`cover   -> ${path.basename(out)}`);
+    } else if (name.includes('.vivlio.colophon.html')) {
+      const out = path.join(rootDir, `${prefix}.vivlio.colophon.html`);
+      fs.copyFileSync(full, out);
+      console.log(`colophon-> ${path.basename(out)}`);
+    } else if (name.includes('.vivlio.config.js')) {
+      const out = path.join(rootDir, `${prefix}.vivlio.config.js`);
+      let data = fs.readFileSync(full, 'utf8');
+      data = data
+        .split('_pdf.vivlio.cover.html').join(`${prefix}.vivlio.cover.html`)
+        .split('_pdfcolophon.vivlio.colophon.html').join(`${prefix}.vivlio.colophon.html`);
+      fs.writeFileSync(out, data, 'utf8');
+      console.log(`config  -> ${path.basename(out)}`);
+    }
+  }
+}
+
+(function main() {
+  const root = process.argv[2];
+  if (!root || !fs.existsSync(root)) {
+    console.error(`collect_config: language root not found: ${root}`);
+    process.exit(1);
+  }
+  // Windows 版に合わせ、ルート直下のサブディレクトリのみを起点に再帰する
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      processDir(root, path.join(root, entry.name));
+    }
+  }
+})();

--- a/exampleSite/CI/linux/package.json
+++ b/exampleSite/CI/linux/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "pdf-linux",
+  "version": "1.0.0",
+  "description": "Linux/Docker PDF build toolchain for hugo-theme-vivliocli",
+  "private": true,
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@vivliostyle/cli": "^8.6.0",
+    "playwright-core": "^1.40.0"
+  }
+}

--- a/exampleSite/CI/linux/pre_js_rendering.js
+++ b/exampleSite/CI/linux/pre_js_rendering.js
@@ -1,0 +1,91 @@
+/*
+ * pre_js_rendering.js (Linux/Docker)
+ *
+ * Linux 移植版。Windows の pre_js_rendering.ps1 + pre_js_rendering.js を 1 本に統合したもの。
+ *
+ * 指定ディレクトリ配下の *.html を再帰的に走査し、マーカー "@pre_rendering_type_js" を
+ * 含むファイル（MathJax / Mermaid を使うページ）をヘッドレス Chromium で開いて
+ * JS 実行後の静的 HTML に上書き保存する。これにより Vivliostyle が JS を実行できなくても
+ * 数式・図がレンダリング済みの状態で PDF 化できる。
+ *
+ * MathJax / Mermaid は jsdelivr CDN から読み込むためネットワーク接続が必要。
+ *
+ * Usage: node pre_js_rendering.js <publish_dir>
+ * Browser: 環境変数 CHROMIUM_PATH（例 /usr/bin/chromium）で実行ファイルを指定。
+ */
+const fs = require('fs');
+const path = require('path');
+const playwright = require('playwright-core');
+
+const MARKER = '@pre_rendering_type_js';
+
+function collectHtmlFiles(dir, acc) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectHtmlFiles(full, acc);
+    } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.html')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+function launchOptions() {
+  const opts = { headless: true, args: ['--no-sandbox', '--disable-dev-shm-usage'] };
+  if (process.env.CHROMIUM_PATH) {
+    opts.executablePath = process.env.CHROMIUM_PATH;
+  } else if (process.env.PLAYWRIGHT_CHANNEL) {
+    opts.channel = process.env.PLAYWRIGHT_CHANNEL; // e.g. "msedge" / "chrome" for local dev
+  }
+  return opts;
+}
+
+(async () => {
+  const targetDir = process.argv[2];
+  if (!targetDir || !fs.existsSync(targetDir)) {
+    console.error(`pre_js_rendering: target dir not found: ${targetDir}`);
+    process.exit(1);
+  }
+
+  console.log('-------------------------------');
+  console.log('Pre javascript rendering');
+  console.log(`target dir: ${targetDir}`);
+  console.log('-------------------------------');
+
+  const htmlFiles = collectHtmlFiles(targetDir, []);
+  const targets = htmlFiles.filter((f) => fs.readFileSync(f, 'utf8').includes(MARKER));
+
+  if (targets.length === 0) {
+    console.log('No pre-rendering required files found.');
+    return;
+  }
+
+  console.log(`Pre rendering required files exist. (Number of files: ${targets.length})`);
+
+  const browser = await playwright.chromium.launch(launchOptions());
+  try {
+    for (const file of targets) {
+      console.log(`rendering...${file}`);
+      const page = await browser.newPage();
+      try {
+        const url = 'file://' + path.resolve(file).split(path.sep).join('/');
+        await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
+        // CDN(MathJax/Mermaid) のレンダリング完了を待つための追加バッファ
+        await page.waitForTimeout(1500);
+        const content = await page.content();
+        fs.writeFileSync(file, content, 'utf8');
+        console.log('OK.');
+      } finally {
+        await page.close();
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+
+  console.log(`Pre rendering is completed. (Number of files: ${targets.length})`);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/exampleSite/CI/linux/run_vivlio.js
+++ b/exampleSite/CI/linux/run_vivlio.js
@@ -1,0 +1,61 @@
+/*
+ * run_vivlio.js (Linux/Docker)
+ *
+ * Linux 移植版。Windows の vivliocli.ps1 と同じ役割。
+ *
+ * 言語ルート直下の *.vivlio.config.js それぞれに対して
+ *   vivliostyle build -c <config> --executable-browser $CHROMIUM_PATH
+ * を実行して PDF を生成する。Vivliostyle は output / entry を config 配置ディレクトリ
+ * 基準で解決するため、cwd を config のディレクトリに設定して実行する。
+ *
+ * Usage: node run_vivlio.js <language_root_dir>
+ */
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+(function main() {
+  const dir = process.argv[2];
+  if (!dir || !fs.existsSync(dir)) {
+    console.error(`run_vivlio: target dir not found: ${dir}`);
+    process.exit(1);
+  }
+
+  const configs = fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith('.vivlio.config.js'))
+    .map((e) => e.name);
+
+  if (configs.length === 0) {
+    console.log(`No vivlio config found in ${dir}. Skip.`);
+    return;
+  }
+
+  const vivlioBin = path.resolve(__dirname, 'node_modules', '.bin', process.platform === 'win32' ? 'vivliostyle.cmd' : 'vivliostyle');
+
+  for (const cfg of configs) {
+    console.log('-------------------------------------');
+    console.log(`Build PDF with config: ${cfg}`);
+    console.log('-------------------------------------');
+
+    const args = ['build', '-c', cfg];
+    if (process.env.CHROMIUM_PATH) {
+      args.push('--executable-browser', process.env.CHROMIUM_PATH);
+    }
+    // Docker(root)では Chromium のサンドボックスを無効化しないと起動できない
+    if (process.env.CHROMIUM_PATH || process.env.VIVLIO_NO_SANDBOX === '1') {
+      args.push('--no-sandbox');
+    }
+
+    const res = spawnSync(vivlioBin, args, {
+      cwd: dir,
+      stdio: 'inherit',
+      env: process.env,
+    });
+
+    if (res.status !== 0) {
+      console.error(`vivliostyle build failed for ${cfg} (exit ${res.status})`);
+      process.exit(res.status || 1);
+    }
+  }
+})();


### PR DESCRIPTION
## 概要

これまで PDF 生成パイプラインは **Windows 専用**（`exampleSite/CI/windows/` の `build_pdf.bat` + PowerShell + Playwright の `msedge` チャンネル）で、Windows 以外の環境・CI では PDF を作れませんでした。

本 PR では **Debian ベースの Docker** 上で「exampleSite の Hugo ビルド」と「Vivliostyle による PDF 生成」を完結させ、**GitHub Actions で PDF 生成まで自動実行**して成果物を Artifact として取得できるようにします。既存の Windows 用 CI は維持し、Linux 版を新規追加します（既存ユーザー無影響）。

## 変更内容

### Docker
- **`Dockerfile`**（Debian bookworm）: Hugo extended v0.163.1 / Node 20 / Chromium / Ghostscript / poppler-utils / Noto CJK / fontconfig を同梱
- **`docker/fonts.conf`**: テーマ CSS が指定する `Yu Gothic` / `Consolas` 等を Noto CJK へエイリアス（豆腐化・代替フォント化を防止）
- **`docker-compose.yml`**: `pdf`（PDF 生成）/ `preview`（`hugo server`）サービス
- **`.dockerignore`**

### Linux ビルドツールチェーン（`exampleSite/CI/linux/`）
Windows スクリプトの挙動を 1:1 で移植:
- `build_pdf.sh` — オーケストレーション（npm install → `hugo`(isPDF=true) → 事前レンダリング → config 集約 → vivliostyle → PDF 集約）
- `pre_js_rendering.js` — MathJax/Mermaid を Chromium で事前レンダリング（`msedge` 依存を排除、`networkidle` 待ち）
- `collect_config.js` — `*.vivlio.*` を言語ルートへフラット化し cover/colophon 参照を書き換え（`CollectConfig.ps1` 移植）
- `run_vivlio.js` — `vivliostyle build`（root コンテナ向けに `--no-sandbox`）
- `package.json` — `@vivliostyle/cli` + `playwright-core`

### CI
- **`.github/workflows/pdf.yml`**: コンテナで PDF をビルドし `vivliocli-pdf` Artifact として upload。**既存 `gh-pages.yml`（サイトデプロイ）は不変更**。

### その他
- `README.md` に Docker でのビルド手順を追記
- `.gitignore` に Linux ビルド成果物（`exampleSite/CI/linux/out/`）を追加

## レビュアーへの補足

- **テーマ解決の仕組み**: `hugo.toml` の `themesdir="../.."` + `theme="hugo-theme-vivliocli"` により、リポジトリは `hugo-theme-vivliocli` という名前のディレクトリに置く必要があります（GitHub の二重ネスト checkout が成立する理由と同じ）。Dockerfile は `WORKDIR /work/hugo-theme-vivliocli` でこれを満たします。
- **ネットワーク必須**: MathJax/Mermaid は jsdelivr CDN から取得するため、事前レンダリング時にネットワーク接続が必要です。

## 検証状況

ローカル（Hugo 0.163.1 + Node 22、Docker 無し）で確認済み:
- ✅ 全スクリプトの構文チェック
- ✅ `hugo`(isPDF=true) ビルド成功（エラー 0）、`en/Manual`・`ja/Manual`・`ja/twoColumns` の vivlio config/cover/colophon 出力を確認
- ✅ `collect_config.js` のフラット化と cover/colophon 参照書き換え（entry パスは維持）を生成 config で確認

Docker ホストでの未検証分（CI / ローカル Docker で要確認）:
- ⏳ `docker build`（apt パッケージ・Hugo deb・Chromium・フォント）
- ⏳ Chromium 事前レンダリング + `vivliostyle build` による PDF 生成
- ⏳ **品質ゲート**: 生成 PDF をページ画像化し、表紙/目次/CJK 本文/表/Mermaid/数式の崩れ・豆腐・フォント代替を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)