### PR TITLE
chore: theme.toml の min_version を Hugo 0.163.1 に合わせる

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -8,7 +8,7 @@ description = "HUGO theme for Vivliosytle-cli."
 homepage = "http://example.com/"
 tags = []
 features = []
-min_version = "0.113.0"
+min_version = "0.163.1"
 
 [author]
   name = "mochimochiki"


### PR DESCRIPTION
v0.24.0 のタグを切る前の整合取りです。

## 何が食い違っていたか

出力フォーマット用テンプレートを `._outputformat_X_.` 形式にリネームした時点（`.agent/ADR.md` の ADR-260614-01）で、このテーマは実質的に **Hugo 0.163.1 以上を要求**するようになっていました。README にもそう書いてあります。

一方 `theme.toml` の `min_version` は **0.113.0** のままでした。

```toml
-min_version = "0.113.0"
+min_version = "0.163.1"
```

## なぜ直しておきたいか

古い Hugo だと `._outputformat_X_.` 形式のテンプレートが認識されず、PDF 用の設定ファイル・表紙・奥付が生成されません。しかもビルド自体は通ってしまうため、原因が分かりにくい。`min_version` を正しくしておけば Hugo 側が起動時に警告を出してくれます。

## 確認

Hugo 0.163.1 で exampleSite をビルドし、警告・エラーがゼロであることを確認しました。

## 補足（今回は触っていません）

同じ `theme.toml` に次の2つも残っています。必要なら別途どうぞ。

- `homepage = "http://example.com/"` … プレースホルダのまま
- `licenselink` のリポジトリ名が `hugo-theme-vivlio`（`cli` 落ち）で 404 になる

---
_Generated by [Claude Code](https://claude.ai/code/session_017nCXmVAVBHJymYHpR8soNb)_